### PR TITLE
yay, automatically store medium and small versions of our images

### DIFF
--- a/cc/images.py
+++ b/cc/images.py
@@ -1,0 +1,16 @@
+# https://pillow.readthedocs.io/en/3.1.x/reference/Image.html
+
+import os, logging
+from PIL import Image
+
+def resize(input_file, output_file, size=None) -> None:
+    try:
+        img = Image.open(input_file)
+        if size is None:
+            # halves each dimension 
+            size = int(img.size[0] / 2), int(img.size[1] / 2)
+        img.thumbnail(size, Image.ANTIALIAS)
+        img.save(output_file)  #, "PNG")
+    except Exception as e:
+        logging.error(f'images.resize {e}')
+        

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -9,3 +9,4 @@ google-cloud-datastore==1.8.0
 google-cloud-firestore==1.2.0
 google-cloud-pubsub==0.41.0
 google-cloud-storage==1.16.0
+Pillow==6.0.0


### PR DESCRIPTION
When we receive an upload message from a new brain (over mqtt),
save a medium and small version of the image in the same storage bucket.

UI developer just has to replace '.png' at the end of the public URL with '_medium.png' or '_small.png'.

e.g. this image was just uploaded by ACE4 (an old PFC):
https://storage.googleapis.com/openag-v1-images/EDU-D41F7C6-f4-5e-ab-59-ac-e3_Camera-Top_2019-06-28T16%3A07%3A30Z.png

The new mqtt service also made these:
https://storage.googleapis.com/openag-v1-images/EDU-D41F7C6-f4-5e-ab-59-ac-e3_Camera-Top_2019-06-28T01%3A07%3A18Z_medium.png

https://storage.googleapis.com/openag-v1-images/EDU-D41F7C6-f4-5e-ab-59-ac-e3_Camera-Top_2019-06-28T01%3A07%3A18Z_small.png

Rob is deploying an updated mqtt service now.